### PR TITLE
fix "fatal: Need to specify how to reconcile divergent branches."

### DIFF
--- a/example/.github/workflows/build-and-deploy.yml
+++ b/example/.github/workflows/build-and-deploy.yml
@@ -21,8 +21,6 @@ jobs:
     name: 'Build And Trigger Platform Deployment'
     runs-on: ubuntu-22.04
     steps:
-      - name: 'Checkout actions'
-        uses: actions/checkout@v3
       - name: 'Build with CircleCI and Deploy via Platform'
         uses: labforward/platform-gha/platform/delivery@0.0.8
         with:

--- a/example/.github/workflows/create-platform-commit.yml
+++ b/example/.github/workflows/create-platform-commit.yml
@@ -21,8 +21,6 @@ jobs:
     name: 'Commit chartVersion to Platform Branch'
     runs-on: ubuntu-22.04
     steps:
-      - name: 'Checkout actions'
-        uses: actions/checkout@v3
       - name: 'Create platform-deployment Branch'
         uses: labforward/platform-gha/platform/branch/create@0.0.8
         with:

--- a/example/.github/workflows/trigger-circleci.yml
+++ b/example/.github/workflows/trigger-circleci.yml
@@ -8,8 +8,6 @@ jobs:
     name: 'Trigger CircleCI Build'
     runs-on: ubuntu-22.04
     steps:
-      - name: 'Checkout actions'
-        uses: actions/checkout@v3
       - name: 'Trigger CircleCI Build'
         uses: labforward/platform-gha/circleci/trigger@0.0.8
         with:

--- a/platform/branch/create/action.yml
+++ b/platform/branch/create/action.yml
@@ -59,7 +59,7 @@ runs:
         git config user.name "GitHub Actions"
         git config user.email "<>"
         git checkout -b ${{ inputs.platform_branch }}
-        git pull --set-upstream origin ${{ inputs.platform_branch }} | true
+        git pull --rebase --set-upstream origin ${{ inputs.platform_branch }} | true
 
     - name: Pass Variables to Env
       shell: bash


### PR DESCRIPTION
which would later failed the deployment because gha failed to push the updated branch with

```
error: failed to push some refs to 'https://github.com/labforward/platform-deployment'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Integrate the remote changes (e.g.
hint: 'git pull ...') before pushing again.
```

sample of failed run: https://github.com/labforward/laboperator-server/actions/runs/3563660946/jobs/5986708350