### PR TITLE
removing old branch reference and stating clean

### DIFF
--- a/platform/branch/create/action.yml
+++ b/platform/branch/create/action.yml
@@ -61,7 +61,7 @@ runs:
         cd platform-deployment 
         git config user.name "GitHub Actions"
         git config user.email "<>"
-        [ '${{ inputs.reuse_branch }}' = 'true' ] && echo "reusing branch" || git push origin --delete ${{ inputs.platform_branch }} && echo "old branch deleted" || echo "no existing old branch to delete"
+        [ '${{ inputs.reuse_branch }}' = 'false' ] && git push origin --delete ${{ inputs.platform_branch }} 
         git checkout -b ${{ inputs.platform_branch }}
         git pull --rebase --set-upstream origin ${{ inputs.platform_branch }} | true
 

--- a/platform/branch/create/action.yml
+++ b/platform/branch/create/action.yml
@@ -58,6 +58,7 @@ runs:
         cd platform-deployment 
         git config user.name "GitHub Actions"
         git config user.email "<>"
+        git push origin --delete ${{ inputs.platform_branch }} && echo "old branch deleted" || echo "no existing old branch to delete"
         git checkout -b ${{ inputs.platform_branch }}
         git pull --rebase --set-upstream origin ${{ inputs.platform_branch }} | true
 

--- a/platform/branch/create/action.yml
+++ b/platform/branch/create/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: 'Branch name used to build. It will be used the last commit available in this branch. Defaults to the branch triggering the workflow.'
     default: ${GITHUB_REF#refs/heads/}
     required: true
+  reuse_branch:
+    description: 'Reuse an existing branch -or- delete the existing branch and create a new one'
+    default: false
   platform_branch:
     description: 'Name of the branch created in the platform-deployment repository. Defaults to gha-${current-branch-name}'
     default: gha-${GITHUB_REF##*/}
@@ -58,7 +61,7 @@ runs:
         cd platform-deployment 
         git config user.name "GitHub Actions"
         git config user.email "<>"
-        git push origin --delete ${{ inputs.platform_branch }} && echo "old branch deleted" || echo "no existing old branch to delete"
+        [ '${{ inputs.reuse_branch }}' = 'true' ] && echo "reusing branch" || git push origin --delete ${{ inputs.platform_branch }} && echo "old branch deleted" || echo "no existing old branch to delete"
         git checkout -b ${{ inputs.platform_branch }}
         git pull --rebase --set-upstream origin ${{ inputs.platform_branch }} | true
 

--- a/platform/delivery/action.yml
+++ b/platform/delivery/action.yml
@@ -59,7 +59,7 @@ runs:
         docker_build_job_name: ${{ inputs.docker_build_job_name }}
 
     - name: 'Create platform-deployment Branch'
-      uses: labforward/platform-gha/platform/branch/create@1.0.1
+      uses: labforward/platform-gha/platform/branch/create@chore/recreate-branch-for-each-build
       with:
         gh_pat: ${{ inputs.gh_pat }}
         apps: ${{ inputs.apps }}

--- a/platform/delivery/action.yml
+++ b/platform/delivery/action.yml
@@ -59,7 +59,7 @@ runs:
         docker_build_job_name: ${{ inputs.docker_build_job_name }}
 
     - name: 'Create platform-deployment Branch'
-      uses: labforward/platform-gha/platform/branch/create@chore/recreate-branch-for-each-build
+      uses: labforward/platform-gha/platform/branch/create@1.0.1
       with:
         gh_pat: ${{ inputs.gh_pat }}
         apps: ${{ inputs.apps }}

--- a/platform/delivery/action.yml
+++ b/platform/delivery/action.yml
@@ -59,7 +59,7 @@ runs:
         docker_build_job_name: ${{ inputs.docker_build_job_name }}
 
     - name: 'Create platform-deployment Branch'
-      uses: labforward/platform-gha/platform/branch/create@1.0.1
+      uses: labforward/platform-gha/platform/branch/create@1.1.0
       with:
         gh_pat: ${{ inputs.gh_pat }}
         apps: ${{ inputs.apps }}

--- a/platform/delivery/action.yml
+++ b/platform/delivery/action.yml
@@ -15,6 +15,9 @@ inputs:
     description: 'Branch name used to build. It will be used the last commit available in this branch. Defaults to the branch triggering the workflow.'
     default: ${GITHUB_REF#refs/heads/}
     required: true
+  reuse_branch:
+    description: 'Reuse an existing branch -or- delete the existing branch and create a new one'
+    default: false
   platform_branch:
     description: 'Name of the branch created in the platform-deployment repository. Defaults to gha-${current-branch-name}'
     default: gha-${GITHUB_REF##*/}
@@ -61,3 +64,4 @@ runs:
         gh_pat: ${{ inputs.gh_pat }}
         apps: ${{ inputs.apps }}
         chart_name: ${{ inputs.chart_name }}
+        reuse_branch: ${{ inputs.reuse_branch }}


### PR DESCRIPTION
Removing a previous branch has been used a lot to solve errors in the apps, so I propose performing this as a standard step on the build and deploy action.